### PR TITLE
Modify ./termdic/termdic.py to use "espeak" instead of "say" in Linux

### DIFF
--- a/termdic/termdic.py
+++ b/termdic/termdic.py
@@ -5,7 +5,7 @@ import re
 import sys
 import requests
 from termcolor import colored as cl
-
+import platform
 
 def look_up(word):
     url = 'http://dict.youdao.com/search?q='
@@ -74,7 +74,10 @@ def main():
         look_up(word)
         if args[opt_pos] == '-p':
             try:
-                os.system('say ' + str(word))
+                if platform.system() == 'Darwin':
+                    os.system('say ' + str(word))
+                else:
+                    os.system('espeak ' + str(word))
             except:
                 pass
 


### PR DESCRIPTION
Linux的“espeak”可起到OS X的“say”的作用，因此“查询单词并发音”的功能在Linux上也可性了。

如果用户的系统是OS X，执行“say word”；
否则，执行“espeak word”。
